### PR TITLE
Make hideWholePostExcerpts an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,18 @@ This plugin runs through all your posts, if your post has more than the configur
 ## Configuration
 
 You can specify the size of the excerpt by setting depth in your config, which defaults to 10.
+
 You can also exclude certain tags from the generated excerpt using css selectors.
 Tags matching any of the selectors will be excluded.
+
+The default behaviour is to only show an excerpt if it would not be the whole post. Set `hideWholePostExcerpts` to `false` to override that and show whole post excerpts.
 
 ``` yaml
 excerpt:
   depth: 10
   excerpt_excludes: []
   more_excludes: []
+  hideWholePostExcerpts: true
 ```
 
 ## License

--- a/lib/hexo-excerpt.js
+++ b/lib/hexo-excerpt.js
@@ -10,7 +10,8 @@ const Filter = require('./dom-filter');
 const DEFAULT_CONFIG = {
   depth: 10,
   excerpt_excludes: [],
-  more_excludes: []
+  more_excludes: [],
+  hideWholePostExcerpts: false
 };
 
 module.exports = function(db) {
@@ -71,8 +72,9 @@ module.exports = function(db) {
     excerptNodes = excerptFilter.filter(excerptNodes);
     moreNodes = moreFilter.filter(moreNodes);
 
-    if (moreNodes.length != 0) {
-      //Only generate excerpt when there is actually more node
+    // If the hideWholePostExcerpts option is set to true (the default), don't show
+    // excerpts for short posts (i.e. ones where the excerpt is the whole post)
+    if (moreNodes.length != 0 || !opts.hideWholePostExcerpts) {
       post.excerpt = (excerptNodes.map(node => domutils.getOuterHTML(node))).join('');
       post.more = (moreNodes.map(node => domutils.getOuterHTML(node))).join('');
     }


### PR DESCRIPTION
When I used this module, I found that all my short blog posts were showing only the title and the date on the homepage.

I tracked it down to the change introduced in this pull request: https://github.com/chekun/hexo-excerpt/pull/6

The change seems very odd to me, and definitely isn't what I want from this module so I added a configuration option to switch between the behaviour introduced in that pull request and the previous behaviour.

Initially I set the default config value to behave post-#6 but the tests were failing. Switching to use the older behaviour by default caused the tests to pass again, so I made that the default.