### PR TITLE
fix: Remove unexpected token

### DIFF
--- a/lib/hexo-excerpt.js
+++ b/lib/hexo-excerpt.js
@@ -33,7 +33,7 @@ module.exports = function(db) {
   return db.posts.map(post => {
 
     //honour the <!-- more --> !!!
-    if (/<!--\s*more\s*-->/.test(post.content) || post.content.indexOf('<a id="more"></a>') !== -1 || || post.content.indexOf('<span id="more"></span>') !== -1) {
+    if (/<!--\s*more\s*-->/.test(post.content) || post.content.indexOf('<a id="more"></a>') !== -1 || post.content.indexOf('<span id="more"></span>') !== -1) {
       return {
         path: post.path,
         data: post,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53979482/131471250-8a297353-eeab-48ea-8429-1228bfa41bc5.png)

When running hexo after installing hexo-excerpt, plugin load failed.

Unexpected token "||" was the cause of the failure.

so, I removed that token in lib/hexo-excerpt.js.