### PR TITLE
Don't process if the excerpt already exists

### DIFF
--- a/lib/hexo-excerpt.js
+++ b/lib/hexo-excerpt.js
@@ -33,7 +33,7 @@ module.exports = function(db) {
   return db.posts.map(post => {
 
     //honour the <!-- more --> !!!
-    if (/<!--\s*more\s*-->/.test(post.content) || post.content.indexOf('<a id="more"></a>') !== -1 || post.content.indexOf('<span id="more"></span>') !== -1) {
+    if (post.excerpt || /<!--\s*more\s*-->/.test(post.content) || post.content.indexOf('<a id="more"></a>') !== -1 || post.content.indexOf('<span id="more"></span>') !== -1) {
       return {
         path: post.path,
         data: post,


### PR DESCRIPTION
When hexo-front-matter-excerpt and hexo-excerpt are used at the same
time, the excerpt generated by the former will be overwritten by the
latter, this commit fix that.

hexo-front-matter-excerpt is a plugin allows to write excerpts in
the YAML front matter.
(https://github.com/lalunamel/hexo-front-matter-excerpt)